### PR TITLE
Fix(migrations): Correct dependency for migration 0013

### DIFF
--- a/StoryJinnProject/StoryJinnator/migrations/0013_rename_age_max_reading_level_max_age_and_more.py
+++ b/StoryJinnProject/StoryJinnator/migrations/0013_rename_age_max_reading_level_max_age_and_more.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('StoryJinnator', '0012_alter_reading_prompt_prompt_id'),
+        ('StoryJinnator', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Migration `StoryJinnator.0013_rename_age_max_reading_level_max_age_and_more` was referencing a non-existent parent migration `0012_alter_reading_prompt_prompt_id`.

This commit updates the dependency of migration `0013` to point to `0001_initial`, which is the most recent existing predecessor in the migrations directory. This resolves the `NodeNotFoundError` encountered when trying to run migrations.